### PR TITLE
WordSieve class for working with all languages through a single object

### DIFF
--- a/lib/stopwords/snowball.rb
+++ b/lib/stopwords/snowball.rb
@@ -1,3 +1,4 @@
 module Stopwords::Snowball
   require_relative 'snowball/filter'
+  require_relative 'snowball/wordsieve'
 end

--- a/lib/stopwords/snowball/wordsieve.rb
+++ b/lib/stopwords/snowball/wordsieve.rb
@@ -1,0 +1,16 @@
+class Stopwords::Snowball::WordSieve
+  def initialize
+    @filters = Dir[File.dirname(__FILE__) + '/locales/*.csv'].each_with_object({}) do |file, filters|
+      lang = File.basename(file, '.csv').to_sym
+      filters[lang] = Stopwords::Snowball::Filter.new lang
+    end
+  end
+
+  def stopword? args={}
+    args[:lang] ? @filters[args[:lang]].stopword?(args[:word] ) : false
+  end
+
+  def filter args={}
+    args[:lang] ? @filters[args[:lang]].filter(args[:words] ) : args[:words]
+  end
+end


### PR DESCRIPTION
Added a **WordSieve** class which could be used with all defined languages

``` ruby
sieve = Stopwords::Snowball::WordSieve.new

filtered = sieve.filter lang: :en, words: ['has', 'cats']
# filtered = ['cats']

sieve.stopword? lang: :en, word: 'some'
# true
```
