### PR TITLE
fix wordsieve

### DIFF
--- a/lib/stopwords/snowball/wordsieve.rb
+++ b/lib/stopwords/snowball/wordsieve.rb
@@ -1,19 +1,19 @@
 module Stopwords
   module Snowball
-    class Stopwords::Snowball::WordSieve
-      def initialize custom_list = []
-        @filters = Dir[File.dirname(__FILE__) + '/locales/*.csv'].each_with_object({}) do |file, filters|
-          lang = File.basename(file, '.csv').to_sym
-          filters[lang] = Stopwords::Snowball::Filter.new lang, custom_list
+    class WordSieve
+      def initialize(custom_list = [])
+        @filters = Dir["#{File.dirname(__FILE__)}/locales/*.csv"].each_with_object({}) do |file, filters|
+          lang = File.basename(file, '.csv')
+          filters[lang.to_sym] = Stopwords::Snowball::Filter.new lang, custom_list
         end
       end
 
-      def stopword? args={}
-        args[:lang] ? @filters[args[:lang]].stopword?(args[:word] ) : false
+      def stopword?(args = {})
+        args[:lang] ? @filters[args[:lang]].stopword?(args[:word]) : false
       end
 
-      def filter args={}
-        args[:lang] ? @filters[args[:lang]].filter(args[:words] ) : args[:words]
+      def filter(args = {})
+        args[:lang] ? @filters[args[:lang]].filter(args[:words]) : args[:words]
       end
     end
   end

--- a/spec/lib/wordsieve_spec.rb
+++ b/spec/lib/wordsieve_spec.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+require_relative('../spec_helper')
+
+describe Stopwords::Snowball::WordSieve do
+  subject { Stopwords::Snowball::WordSieve.new }
+  let(:words) { 'guide by douglas adams'.split }
+
+  describe '#filter' do
+    it('should remove the stopwords from the list of words') do
+      expect(subject.filter(lang: :en, words: words)).to eq(%w[guide douglas adams])
+    end
+  end
+
+  describe '#stopwords' do
+    it('should return true for stopwords') do
+      expect(subject.stopword?(lang: :en, word: 'by')).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
The current release 0.6 is unfortunately broken. With the PR #16 the API of the `Snowball::Filter` changed and
only accepts strings. The `class Wordsieve` initializes the
`Snowball::Filter` with symbols which result in a:

```
NoMethodError: undefined method `gsub' for :af:Symbol
```

This will fix the bug and adds some basic tests on the `Wordsieve` class.